### PR TITLE
Add feature support for TURN_ON/TURN_OFF to support the climate.turn_on/off service calls

### DIFF
--- a/custom_components/climate_group/climate.py
+++ b/custom_components/climate_group/climate.py
@@ -85,6 +85,8 @@ SUPPORT_FLAGS = (
     | ClimateEntityFeature.PRESET_MODE
     | ClimateEntityFeature.SWING_MODE
     | ClimateEntityFeature.FAN_MODE
+    | ClimateEntityFeature.TURN_ON
+    | ClimateEntityFeature.TURN_OFF
 )
 
 def round_decimal_accuracy(


### PR DESCRIPTION
Add the feature support for climate.TURN_ON and climate.TURN_OFF.

While this is not necessary for the standard UI widgets that use the `climate.set_hvac_mode` service call to turn on/off, these are required to be able to use the `climate.turn_on` and `climate.turn_off` service calls. 

The `climate.turn_on` and `climate.turn_off` service calls are what are called by the Google Assistant integration for turn on/off actions and therefore without this support the group entity can not be used to turn on/off the climate group from google assistant.